### PR TITLE
added code to remediate the Snyk findings

### DIFF
--- a/staging/Vuln-file/vulnerable.tf
+++ b/staging/Vuln-file/vulnerable.tf
@@ -5,16 +5,16 @@ resource "aws_s3_bucket" "example" {
 resource "aws_s3_bucket_public_access_block" "example" {
   bucket = aws_s3_bucket.example.id
 
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   size              = 40
-
+  encrypted         = true
   tags = {
     Name = "HelloWorld"
   }
@@ -22,12 +22,12 @@ resource "aws_ebs_volume" "example" {
 
 
 resource "aws_lb" "test" {
-  name               = "test-lb-tf"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.lb_sg.id]
-  subnets            = [for subnet in aws_subnet.public : subnet.id]
-
+  name                       = "test-lb-tf"
+  internal                   = true
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.lb_sg.id]
+  subnets                    = [for subnet in aws_subnet.public : subnet.id]
+  drop_invalid_header_fields = true
   enable_deletion_protection = false
 
   tags = {
@@ -38,7 +38,7 @@ resource "aws_lb" "test" {
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.front_end.arn
   port              = "80"
-  protocol          = "HTTP"
+  protocol          = "HTTPS" #setting to HTPS for more secure connection
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.front_end.arn


### PR DESCRIPTION
This PR is to addressed the below issues;

SNYK-CC-TF-47-Load balancer endpoint does not enforce HTTPS
SNYK-CC-AWS-405-ALB does not drop invalid headers
SNYK-CC-TF-3-Non-encrypted EBS volume
SNYK-CC-TF-95-S3 block public ACLs control is disabled
SNYK-CC-TF-96-S3 block public policy control is disabled
SNYK-CC-TF-97-S3 ignore public ACLs control is disabled
SNYK-CC-TF-98-S3 restrict public bucket control is disabled
SNYK-CC-TF-48-Load balancer is internet facing